### PR TITLE
Add write-only secret support to client resource

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,24 @@
+# AGENTS.md
+
+## Build & Test
+- `go build .` - build binary
+- `go install .` - install provider to `$GOBIN`
+- `make test` - run unit tests only
+- `make acc-test` - runs acceptance tests (requires k8s + Dex helm chart, defined in Makefile)
+
+## Docs
+- `go generate ./...` - regenerate provider documentation (not `go doc`)
+
+## Provider Config
+- Provider address: `hashicorp.com/marcofranssen/dexidp`
+- Framework: `terraform-plugin-framework`
+
+## Commit Style
+- Commits in present tense
+- One feature per branch
+- Rebase on main before PR
+- Include docs updates in same commit as code changes
+
+## Local Testing
+- Set up `.terraformrc` with dev_overrides pointing to your `$GOBIN`
+- Use `tfenv use` to match `.terraform-version`

--- a/docs/resources/client.md
+++ b/docs/resources/client.md
@@ -31,12 +31,16 @@ resource "dexidp_client" "my_oidc_client" {
 - `client_id` (String) The ID of your Dex oauth2 client.
 - `name` (String) The name of your Dex oauth2 client.
 - `redirect_uris` (List of String) The allowed redirect_uris for this Dex Oauth2 client.
-- `secret` (String, Sensitive) The Secret of your Dex oauth2 client.
 
 ### Optional
 
+> **NOTE**: [Write-only arguments](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments) are supported in Terraform 1.11 and later.
+
 - `logo_url` (String) The url to the logo of your Dex oauth2 client.
 - `public` (Boolean)
+- `secret` (String) The Secret of your Dex oauth2 client.
+- `secret_wo` (String, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) The Secret of your Dex oauth2 client (write-only, not persisted to state).
+- `secret_wo_version` (String) Version for write-only secret validation.
 - `trusted_peers` (List of String) The trusted peers for this Dex Oauth2 client.
 
 ### Read-Only

--- a/pkg/dexidp/dexclient_resource.go
+++ b/pkg/dexidp/dexclient_resource.go
@@ -32,15 +32,17 @@ type dexClientResoure struct {
 }
 
 type dexClientModel struct {
-	ID           types.String `tfsdk:"id"`
-	ClientID     types.String `tfsdk:"client_id"`
-	Secret       types.String `tfsdk:"secret"`
-	Name         types.String `tfsdk:"name"`
-	Public       types.Bool   `tfsdk:"public"`
-	LogoURL      types.String `tfsdk:"logo_url"`
-	RedirectURIs types.List   `tfsdk:"redirect_uris"`
-	TrustedPeers types.List   `tfsdk:"trusted_peers"`
-	LastUpdated  types.String `tfsdk:"last_updated"`
+	ID              types.String `tfsdk:"id"`
+	ClientID        types.String `tfsdk:"client_id"`
+	Secret          types.String `tfsdk:"secret"`
+	SecretWo        types.String `tfsdk:"secret_wo"`
+	SecretWoVersion types.String `tfsdk:"secret_wo_version"`
+	Name            types.String `tfsdk:"name"`
+	Public          types.Bool   `tfsdk:"public"`
+	LogoURL         types.String `tfsdk:"logo_url"`
+	RedirectURIs    types.List   `tfsdk:"redirect_uris"`
+	TrustedPeers    types.List   `tfsdk:"trusted_peers"`
+	LastUpdated     types.String `tfsdk:"last_updated"`
 }
 
 // Configure adds the provider configured client to the resource.
@@ -76,8 +78,16 @@ func (r *dexClientResoure) Schema(_ context.Context, _ resource.SchemaRequest, r
 			},
 			"secret": schema.StringAttribute{
 				Description: "The Secret of your Dex oauth2 client.",
-				Required:    true,
-				Sensitive:   true,
+				Optional:    true,
+			},
+			"secret_wo": schema.StringAttribute{
+				Description: "The Secret of your Dex oauth2 client (write-only, not persisted to state).",
+				Optional:    true,
+				WriteOnly:   true,
+			},
+			"secret_wo_version": schema.StringAttribute{
+				Description: "Version for write-only secret validation.",
+				Optional:    true,
 			},
 			"public": schema.BoolAttribute{
 				Optional: true,
@@ -115,13 +125,24 @@ func (r *dexClientResoure) Create(ctx context.Context, req resource.CreateReques
 		return
 	}
 
+	var secretWo types.String
+	diags = req.Config.GetAttribute(ctx, path.Root("secret_wo"), &secretWo)
+	resp.Diagnostics.Append(diags...)
+
+	var clientSecret string
+	if !secretWo.IsNull() && secretWo.ValueString() != "" {
+		clientSecret = secretWo.ValueString()
+	} else {
+		clientSecret = plan.Secret.ValueString()
+	}
+
 	redirectURIs := utils.ListStringValuesToSlice(plan.RedirectURIs)
 	trustedPeers := utils.ListStringValuesToSlice(plan.TrustedPeers)
 
 	createClientReq := api.CreateClientReq{
 		Client: &api.Client{
 			Id:           plan.ClientID.ValueString(),
-			Secret:       plan.Secret.ValueString(),
+			Secret:       clientSecret,
 			Name:         plan.Name.ValueString(),
 			Public:       plan.Public.ValueBool(),
 			RedirectUris: redirectURIs,
@@ -180,7 +201,6 @@ func (r *dexClientResoure) Read(ctx context.Context, req resource.ReadRequest, r
 	state.ClientID = state.ID
 	state.Name = types.StringValue(c.Name)
 	state.LogoURL = types.StringValue(c.LogoUrl)
-	state.Secret = types.StringValue(c.Secret)
 	redirectURIs, _ := types.ListValueFrom(ctx, types.StringType, c.RedirectUris)
 	trustedPeers, _ := types.ListValueFrom(ctx, types.StringType, c.TrustedPeers)
 	state.RedirectURIs = redirectURIs


### PR DESCRIPTION
## Summary

Adds `secret_wo` (write-only) and `secret_wo_version` attributes to the client resource following Terraform's ephemeral values best practices. Write-only arguments are not persisted to state, preventing sensitive credentials from being stored in Terraform state files.

Requires Terraform 1.11+ for write-only arguments support.

## Changes

- Add `secret_wo` (write-only) attribute - accepts secret but never persists to state
- Add `secret_wo_version` attribute for version validation
- Modify Create to read secret from config for write-only value
- Modify Read to not populate secret from API response (write-only)
- Update documentation with write-only attribute details
- Add AGENTS.md for developer instructions

Closes #231