### PR TITLE
Add smarter error message for unimplemented GetClient

### DIFF
--- a/pkg/dexidp/dexclient_resource.go
+++ b/pkg/dexidp/dexclient_resource.go
@@ -183,9 +183,13 @@ func (r *dexClientResoure) Read(ctx context.Context, req resource.ReadRequest, r
 		if isUnimplementedError(err) {
 			resp.Diagnostics.AddError(
 				"Error getting Dex client",
-				"The Dex server does not support the GetClient method. "+
-					"This usually means you need to upgrade your Dex server to a newer version. "+
-					"The GetClient method was added in Dex API v2 (Dex v2.37+).",
+				fmt.Sprintf(
+					"The Dex server does not support the GetClient method. "+
+						"This usually means you need to upgrade your Dex server to a newer version. "+
+						"The GetClient method was added in Dex API v2 (Dex v2.37+). "+
+						"Original RPC error: %v",
+					err,
+				),
 			)
 		} else {
 			resp.Diagnostics.AddError(

--- a/pkg/dexidp/dexclient_resource.go
+++ b/pkg/dexidp/dexclient_resource.go
@@ -3,6 +3,7 @@ package dexidp
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/dexidp/dex/api/v2"
@@ -11,6 +12,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/marcofranssen/terraform-provider-dexidp/pkg/utils"
 )
@@ -25,6 +28,14 @@ var (
 // NewDexClientResource instantiates a new Dex Client resource.
 func NewDexClientResource() resource.Resource {
 	return &dexClientResoure{}
+}
+
+func isUnimplementedError(err error) bool {
+	st, ok := status.FromError(err)
+	if !ok {
+		return strings.Contains(err.Error(), "Unimplemented")
+	}
+	return st.Code() == codes.Unimplemented
 }
 
 type dexClientResoure struct {
@@ -169,10 +180,19 @@ func (r *dexClientResoure) Read(ctx context.Context, req resource.ReadRequest, r
 	}
 	response, err := r.client.GetClient(ctx, &getReq)
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error getting Dex client",
-			fmt.Sprintf("Could not get Dex client, unexpected error: %v", err),
-		)
+		if isUnimplementedError(err) {
+			resp.Diagnostics.AddError(
+				"Error getting Dex client",
+				"The Dex server does not support the GetClient method. "+
+					"This usually means you need to upgrade your Dex server to a newer version. "+
+					"The GetClient method was added in Dex API v2 (Dex v2.37+).",
+			)
+		} else {
+			resp.Diagnostics.AddError(
+				"Error getting Dex client",
+				fmt.Sprintf("Could not get Dex client, unexpected error: %v", err),
+			)
+		}
 		return
 	}
 	c := response.Client


### PR DESCRIPTION
## Summary

Detects when the Dex server doesn't support the `GetClient` gRPC method and provides a helpful error message suggesting to upgrade Dex.

This addresses issue #140 where users were getting a generic "unknown method GetClient" error without understanding the root cause.

## Changes

- Add `isUnimplementedError()` helper to detect gRPC `Unimplemented` status codes
- Improve error message in `Read` method to explain the likely cause and solution  
- Users should upgrade their Dex server to version supporting GetClient (Dex v2.37+)

## Testing

- `go build .` passes
- `make test` passes

Refs: #140