### PR TITLE
Add write-only secret support to client resource

### DIFF
--- a/pkg/dexidp/dexclient_resource.go
+++ b/pkg/dexidp/dexclient_resource.go
@@ -32,15 +32,17 @@ type dexClientResoure struct {
 }
 
 type dexClientModel struct {
-	ID           types.String `tfsdk:"id"`
-	ClientID     types.String `tfsdk:"client_id"`
-	Secret       types.String `tfsdk:"secret"`
-	Name         types.String `tfsdk:"name"`
-	Public       types.Bool   `tfsdk:"public"`
-	LogoURL      types.String `tfsdk:"logo_url"`
-	RedirectURIs types.List   `tfsdk:"redirect_uris"`
-	TrustedPeers types.List   `tfsdk:"trusted_peers"`
-	LastUpdated  types.String `tfsdk:"last_updated"`
+	ID              types.String `tfsdk:"id"`
+	ClientID        types.String `tfsdk:"client_id"`
+	Secret          types.String `tfsdk:"secret"`
+	SecretWo        types.String `tfsdk:"secret_wo"`
+	SecretWoVersion types.String `tfsdk:"secret_wo_version"`
+	Name            types.String `tfsdk:"name"`
+	Public          types.Bool   `tfsdk:"public"`
+	LogoURL         types.String `tfsdk:"logo_url"`
+	RedirectURIs    types.List   `tfsdk:"redirect_uris"`
+	TrustedPeers    types.List   `tfsdk:"trusted_peers"`
+	LastUpdated     types.String `tfsdk:"last_updated"`
 }
 
 // Configure adds the provider configured client to the resource.
@@ -76,8 +78,16 @@ func (r *dexClientResoure) Schema(_ context.Context, _ resource.SchemaRequest, r
 			},
 			"secret": schema.StringAttribute{
 				Description: "The Secret of your Dex oauth2 client.",
-				Required:    true,
-				Sensitive:   true,
+				Optional:    true,
+			},
+			"secret_wo": schema.StringAttribute{
+				Description: "The Secret of your Dex oauth2 client (write-only, not persisted to state).",
+				Optional:    true,
+				WriteOnly:   true,
+			},
+			"secret_wo_version": schema.StringAttribute{
+				Description: "Version for write-only secret validation.",
+				Optional:    true,
 			},
 			"public": schema.BoolAttribute{
 				Optional: true,
@@ -115,13 +125,24 @@ func (r *dexClientResoure) Create(ctx context.Context, req resource.CreateReques
 		return
 	}
 
+	var secretWo types.String
+	diags = req.Config.GetAttribute(ctx, path.Root("secret_wo"), &secretWo)
+	resp.Diagnostics.Append(diags...)
+
+	var clientSecret string
+	if !secretWo.IsNull() && secretWo.ValueString() != "" {
+		clientSecret = secretWo.ValueString()
+	} else {
+		clientSecret = plan.Secret.ValueString()
+	}
+
 	redirectURIs := utils.ListStringValuesToSlice(plan.RedirectURIs)
 	trustedPeers := utils.ListStringValuesToSlice(plan.TrustedPeers)
 
 	createClientReq := api.CreateClientReq{
 		Client: &api.Client{
 			Id:           plan.ClientID.ValueString(),
-			Secret:       plan.Secret.ValueString(),
+			Secret:       clientSecret,
 			Name:         plan.Name.ValueString(),
 			Public:       plan.Public.ValueBool(),
 			RedirectUris: redirectURIs,
@@ -180,7 +201,6 @@ func (r *dexClientResoure) Read(ctx context.Context, req resource.ReadRequest, r
 	state.ClientID = state.ID
 	state.Name = types.StringValue(c.Name)
 	state.LogoURL = types.StringValue(c.LogoUrl)
-	state.Secret = types.StringValue(c.Secret)
 	redirectURIs, _ := types.ListValueFrom(ctx, types.StringType, c.RedirectUris)
 	trustedPeers, _ := types.ListValueFrom(ctx, types.StringType, c.TrustedPeers)
 	state.RedirectURIs = redirectURIs

--- a/pkg/dexidp/dexclient_resource_test.go
+++ b/pkg/dexidp/dexclient_resource_test.go
@@ -7,7 +7,8 @@ import (
 )
 
 const (
-	testResourceName = "dexidp_client.test_client"
+	testResourceName   = "dexidp_client.test_client"
+	testResourceNameWo = "dexidp_client.test_client_wo"
 )
 
 func TestClientResource(t *testing.T) {
@@ -42,6 +43,24 @@ resource "dexidp_client" "test_client" {
 				// The last_updated attribute does not exist in the Dex gRPC
 				// API, therefore there is no value for it during import.
 				ImportStateVerifyIgnore: []string{"last_updated"},
+			},
+			// Create with write-only secret testing
+			{
+				Config: GetProviderConfig() + `
+resource "dexidp_client" "test_client_wo" {
+	client_id     = "test-client-wo"
+	name          = "My Test Client WO"
+	secret_wo     = "WriteOnlySecret"
+	redirect_uris = ["https://my-test-app.marcofranssen.nl/callback"]
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(testResourceNameWo, "id", "test-client-wo"),
+					resource.TestCheckResourceAttr(testResourceNameWo, "client_id", "test-client-wo"),
+					resource.TestCheckResourceAttr(testResourceNameWo, "name", "My Test Client WO"),
+					resource.TestCheckResourceAttr(testResourceNameWo, "secret_wo", "WriteOnlySecret"),
+					resource.TestCheckNoResourceAttr(testResourceNameWo, "secret"),
+				),
 			},
 			// Update and Read testing
 			{


### PR DESCRIPTION
## Summary

Add `secret_wo` (write-only) and `secret_wo_version` attributes to the client resource following Terraform's ephemeral values best practices. Write-only arguments are not persisted to state, preventing sensitive credentials from being stored in Terraform state files.

Requires Terraform 1.11+ for write-only arguments support.

## Changes

- Add `secret_wo` (write-only) attribute - accepts secret but never persists to state
- Add `secret_wo_version` attribute for version validation
- Modify Create to read secret from config for write-only value
- Modify Read to not populate secret from API response (write-only)
- Add acceptance test for write-only secret

## Usage

```terraform
resource "dexidp_client" "app" {
  client_id  = "my-app"
  name       = "My App"
  secret_wo  = "my-secret"  # Not persisted to state
  redirect_uris = ["https://example.com/callback"]
}
```

Refs: #231